### PR TITLE
Change Mandatory to Optional for  some non-LwM2M (non OMA) objects

### DIFF
--- a/10241.xml
+++ b/10241.xml
@@ -18,7 +18,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 		<LWM2MVersion />
 		<ObjectVersion />
 		<MultipleInstances>Multiple</MultipleInstances>
-		<Mandatory>Mandatory</Mandatory>
+		<Mandatory>Optional</Mandatory>
 		<Resources>
 			<Item ID="5905"><Name>Host Device Manufacturer</Name>
 				<Operations>R</Operations>

--- a/10245.xml
+++ b/10245.xml
@@ -18,7 +18,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
         <LWM2MVersion/>
         <ObjectVersion/>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Mandatory</Mandatory>
+        <Mandatory>Optional</Mandatory>
         <Resources>
             <Item ID="0">
                 <Name>eNB Availability</Name>

--- a/10246.xml
+++ b/10246.xml
@@ -17,7 +17,7 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMA
         <LWM2MVersion/>
         <ObjectVersion/>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Mandatory</Mandatory>
+        <Mandatory>Optional</Mandatory>
         <Resources>
             <Item ID="0">
                 <Name>Serving Cell ID</Name>

--- a/10247.xml
+++ b/10247.xml
@@ -18,7 +18,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
         <LWM2MVersion/>
         <ObjectVersion/>
         <MultipleInstances>Multiple</MultipleInstances>
-        <Mandatory>Mandatory</Mandatory>
+        <Mandatory>Optional</Mandatory>
         <Resources>
             <Item ID="0">
                 <Name>Neighbour PCI</Name>

--- a/10248.xml
+++ b/10248.xml
@@ -17,7 +17,7 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMA
         <LWM2MVersion/>
         <ObjectVersion/>
         <MultipleInstances>Single</MultipleInstances>
-        <Mandatory>Mandatory</Mandatory>
+        <Mandatory>Optional</Mandatory>
         <Resources>
             <Item ID="0">
                 <Name>Number of Connected Users</Name>

--- a/10249.xml
+++ b/10249.xml
@@ -17,7 +17,7 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMA
         <LWM2MVersion/>
         <ObjectVersion/>     
 		<MultipleInstances>Multiple</MultipleInstances>
-		<Mandatory>Mandatory</Mandatory>
+		<Mandatory>Optional</Mandatory>
         <Resources>
             <Item ID="0">
                 <Name>Connected User MMEC</Name>


### PR DESCRIPTION
Convert the last remaining mandatory objects that weren't present in https://github.com/OpenMobileAlliance/lwm2m-registry/pull/95