### PR TITLE
Editorial fix of the description of 18831:0

### DIFF
--- a/18831.xml
+++ b/18831.xml
@@ -52,7 +52,7 @@ https://ioterop.com/
                 <Type>Corelnk</Type>
                 <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
-                <Description><![CDATA[The source of the data to publish (e.g. "</sensors/temp>", or "</3303/0/5700>;</3336/0>"). If this Resource is empty, the published data are implementation dependent.]]></Description>
+                <Description><![CDATA[The source of the data to publish (e.g. "&lt;/sensors/temp&gt;", or "&lt;/3303/0/5700&gt;;&lt;/3336/0&gt;"). If this Resource is empty, the published data are implementation dependent.]]></Description>
             </Item>
             <Item ID="1">
                 <Name>Broker</Name>


### PR DESCRIPTION
Signed-off-by: David Navarro <david.navarro@ioterop.com>

Because of the usage of `<` and `>`, the description of the Resource 0 was rendered as:
> The source of the data to publish (e.g. "", or ";"). If this Resource is empty, the published data are implementation dependent.

With this change, it is correctly rendered as:
> The source of the data to publish (e.g. "</sensors/temp>", or "</3303/0/5700>;</3336/0>"). If this Resource is empty, the published data are implementation dependent.
