### PR TITLE
[BUG] Replace '&lt' and '&gt' with angular open and close brackets

### DIFF
--- a/10326.xml
+++ b/10326.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			</object ID/object instance ID/resoure ID>, for example: </10315/0/2>]]></Description>
+			</object ID/object instance ID/resource ID>, for example: </10315/0/2>]]></Description>
       </Item>
 
       <Item ID="300">

--- a/10326.xml
+++ b/10326.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			&lt;/object ID/object instance ID/resoure ID&gt;, for example:&lt;/10315/0/2&gt;]]></Description>
+			'</object ID/object instance ID/resoure ID>', for example:'</10315/0/2>']]></Description>
       </Item>
 
       <Item ID="300">

--- a/10326.xml
+++ b/10326.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			</object ID/object instance ID/resource ID>, for example: </10315/0/2>]]></Description>
+			</object ID/object instance ID/resource ID>, for example: '</10315/0/2>']]></Description>
       </Item>
 
       <Item ID="300">

--- a/10326.xml
+++ b/10326.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			< /object ID/object instance ID/resoure ID >, for example: < /10315/0/2 >]]></Description>
+			</object ID/object instance ID/resoure ID>, for example: </10315/0/2>]]></Description>
       </Item>
 
       <Item ID="300">

--- a/10326.xml
+++ b/10326.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			'</object ID/object instance ID/resoure ID>', for example:'</10315/0/2>']]></Description>
+			< /object ID/object instance ID/resoure ID >, for example: < /10315/0/2 >]]></Description>
       </Item>
 
       <Item ID="300">

--- a/10326.xml
+++ b/10326.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			</object ID/object instance ID/resource ID>, for example: '</10315/0/2>']]></Description>
+			</object ID/object instance ID/resource ID>, for example: </10315/0/2>]]></Description>
       </Item>
 
       <Item ID="300">

--- a/10332.xml
+++ b/10332.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<RangeEnumeration>4..63</RangeEnumeration>
 		<Units/>
 		<Description>
-		  <![CDATA[Contains the object ID and object instance ID/Name, for example: &lt;/10320/2&gt;.]]>
+		  <![CDATA[Contains the object ID and object instance ID/Name, for example: '</10320/2>'.]]>
 		</Description>
 	  </Item>
       <Item ID="2">

--- a/10332.xml
+++ b/10332.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<RangeEnumeration>4..63</RangeEnumeration>
 		<Units/>
 		<Description>
-		  <![CDATA[Contains the object ID and object instance ID/Name, for example: '</10320/2>'.]]>
+		  <![CDATA[Contains the object ID and object instance ID/Name, for example: < /10320/2 >.]]>
 		</Description>
 	  </Item>
       <Item ID="2">

--- a/10332.xml
+++ b/10332.xml
@@ -61,7 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <Type>Integer</Type>
         <RangeEnumeration/>
         <Units/>
-        <Description><![CDATA[0:Normal, 1:Unknown, <0:Failed with error code(negative number).]]></Description>
+        <Description><![CDATA[0:Normal, 1:Unknown, 0:Failed with error code(negative number).]]></Description>
       </Item>
 	</Resources>
     <Description2 />

--- a/10332.xml
+++ b/10332.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<RangeEnumeration>4..63</RangeEnumeration>
 		<Units/>
 		<Description>
-		  <![CDATA[Contains the object ID and object instance ID/Name, for example: < /10320/2 >.]]>
+		  <![CDATA[Contains the object ID and object instance ID/Name, for example: </10320/2>.]]>
 		</Description>
 	  </Item>
       <Item ID="2">

--- a/10333.xml
+++ b/10333.xml
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<RangeEnumeration/>
 			<Units/>
 			<Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-				'</object ID/object instance ID/resoure ID>', for example:/10322/2/4]]></Description>
+				< /object ID/object instance ID/resoure ID>, for example:/10322/2/4]]></Description>
 		</Item>
 		<Item ID="3">
 			<Name>High Threshold</Name>

--- a/10333.xml
+++ b/10333.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2 >.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Performance Type</Name>

--- a/10333.xml
+++ b/10333.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: &lt;/10320/2&gt;.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Performance Type</Name>
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<RangeEnumeration/>
 			<Units/>
 			<Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-				&lt;/object ID/object instance ID/resoure ID&gt;, for example:/10322/2/4]]></Description>
+				'</object ID/object instance ID/resoure ID>', for example:/10322/2/4]]></Description>
 		</Item>
 		<Item ID="3">
 			<Name>High Threshold</Name>

--- a/10333.xml
+++ b/10333.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2 >.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: </10320/2>.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Performance Type</Name>
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<RangeEnumeration/>
 			<Units/>
 			<Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-				< /object ID/object instance ID/resoure ID>, for example:/10322/2/4]]></Description>
+				</object ID/object instance ID/resoure ID>, for example:/10322/2/4]]></Description>
 		</Item>
 		<Item ID="3">
 			<Name>High Threshold</Name>

--- a/10334.xml
+++ b/10334.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2>.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: </10320/2>.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Probable Cause</Name>

--- a/10334.xml
+++ b/10334.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: &lt;/10320/2&gt;.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Probable Cause</Name>

--- a/10334.xml
+++ b/10334.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2>.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Probable Cause</Name>

--- a/10335.xml
+++ b/10335.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2>.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: </10320/2>.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Event Type</Name>

--- a/10335.xml
+++ b/10335.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2>.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Event Type</Name>

--- a/10335.xml
+++ b/10335.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: &lt;/10320/2&gt;.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Event Type</Name>

--- a/18831.xml
+++ b/18831.xml
@@ -52,7 +52,7 @@ https://ioterop.com/
                 <Type>Corelnk</Type>
                 <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
-                <Description><![CDATA[The source of the data to publish (e.g. "</sensors/temp>", or "</3303/0/5700>;</3336/0>"). If this Resource is empty, the published data are implementation dependent.]]></Description>
+                <Description><![CDATA[The source of the data to publish (e.g. '< /sensors/temp>', or '< /3303/0/5700>; < /3336/0>'). If this Resource is empty, the published data are implementation dependent.]]></Description>
             </Item>
             <Item ID="1">
                 <Name>Broker</Name>

--- a/18831.xml
+++ b/18831.xml
@@ -52,7 +52,7 @@ https://ioterop.com/
                 <Type>Corelnk</Type>
                 <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
-                <Description><![CDATA[The source of the data to publish (e.g. '< /sensors/temp>', or '< /3303/0/5700>; < /3336/0>'). If this Resource is empty, the published data are implementation dependent.]]></Description>
+                <Description><![CDATA[The source of the data to publish (e.g. < /sensors/temp >, or < /3303/0/5700 >; < /3336/0 >). If this Resource is empty, the published data are implementation dependent.]]></Description>
             </Item>
             <Item ID="1">
                 <Name>Broker</Name>

--- a/18831.xml
+++ b/18831.xml
@@ -52,7 +52,7 @@ https://ioterop.com/
                 <Type>Corelnk</Type>
                 <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
-                <Description><![CDATA[The source of the data to publish (e.g. < /sensors/temp >, or < /3303/0/5700 >; < /3336/0 >). If this Resource is empty, the published data are implementation dependent.]]></Description>
+                <Description><![CDATA[The source of the data to publish (e.g. </sensors/temp>, or </3303/0/5700>; </3336/0>). If this Resource is empty, the published data are implementation dependent.]]></Description>
             </Item>
             <Item ID="1">
                 <Name>Broker</Name>

--- a/version_history/10326-1_0.xml
+++ b/version_history/10326-1_0.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			&lt;/object ID/object instance ID/resoure ID&gt;, for example:&lt;/10315/0/2&gt;]]></Description>
+			'</object ID/object instance ID/resoure ID>', for example:'</10315/0/2>']]></Description>
       </Item>
 
       <Item ID="300">

--- a/version_history/10326-1_0.xml
+++ b/version_history/10326-1_0.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			< /object ID/object instance ID/resoure ID >, for example:< /10315/0/2 >]]></Description>
+			</object ID/object instance ID/resoure ID>, for example:</10315/0/2>]]></Description>
       </Item>
 
       <Item ID="300">

--- a/version_history/10326-1_0.xml
+++ b/version_history/10326-1_0.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <RangeEnumeration>0..100</RangeEnumeration>
         <Units>/100</Units>
         <Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-			'</object ID/object instance ID/resoure ID>', for example:'</10315/0/2>']]></Description>
+			< /object ID/object instance ID/resoure ID >, for example:< /10315/0/2 >]]></Description>
       </Item>
 
       <Item ID="300">

--- a/version_history/10332-1_0.xml
+++ b/version_history/10332-1_0.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<RangeEnumeration>4..63</RangeEnumeration>
 		<Units/>
 		<Description>
-		  <![CDATA[Contains the object ID and object instance ID/Name, for example: &lt;/10320/2&gt;.]]>
+		  <![CDATA[Contains the object ID and object instance ID/Name, for example: '</10320/2>'.]]>
 		</Description>
 	  </Item>
       <Item ID="2">

--- a/version_history/10332-1_0.xml
+++ b/version_history/10332-1_0.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<RangeEnumeration>4..63</RangeEnumeration>
 		<Units/>
 		<Description>
-		  <![CDATA[Contains the object ID and object instance ID/Name, for example: '</10320/2>'.]]>
+		  <![CDATA[Contains the object ID and object instance ID/Name, for example: < /10320/2 >.]]>
 		</Description>
 	  </Item>
       <Item ID="2">

--- a/version_history/10332-1_0.xml
+++ b/version_history/10332-1_0.xml
@@ -61,7 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <Type>Integer</Type>
         <RangeEnumeration/>
         <Units/>
-        <Description><![CDATA[0:Normal, 1:Unknown, <0:Failed with error code(negative number).]]></Description>
+        <Description><![CDATA[0:Normal, 1:Unknown, 0:Failed with error code(negative number).]]></Description>
       </Item>
 	</Resources>
     <Description2 />

--- a/version_history/10332-1_0.xml
+++ b/version_history/10332-1_0.xml
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<RangeEnumeration>4..63</RangeEnumeration>
 		<Units/>
 		<Description>
-		  <![CDATA[Contains the object ID and object instance ID/Name, for example: < /10320/2 >.]]>
+		  <![CDATA[Contains the object ID and object instance ID/Name, for example: </10320/2>.]]>
 		</Description>
 	  </Item>
       <Item ID="2">

--- a/version_history/10333-1_0.xml
+++ b/version_history/10333-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2 >.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Performance Type</Name>
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<RangeEnumeration/>
 			<Units/>
 			<Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-				'</object ID/object instance ID/resoure ID>', for example:/10322/2/4]]></Description>
+				< /object ID/object instance ID/resoure ID >, for example: /10322/2/4]]></Description>
 		</Item>
 		<Item ID="3">
 			<Name>High Threshold</Name>

--- a/version_history/10333-1_0.xml
+++ b/version_history/10333-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2 >.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: </10320/2>.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Performance Type</Name>
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<RangeEnumeration/>
 			<Units/>
 			<Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-				< /object ID/object instance ID/resoure ID >, for example: /10322/2/4]]></Description>
+				</object ID/object instance ID/resoure ID>, for example: /10322/2/4]]></Description>
 		</Item>
 		<Item ID="3">
 			<Name>High Threshold</Name>

--- a/version_history/10333-1_0.xml
+++ b/version_history/10333-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: &lt;/10320/2&gt;.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Performance Type</Name>
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<RangeEnumeration/>
 			<Units/>
 			<Description><![CDATA[Referrence to a PM item, similar with Corelnk in LwM2M 1.1, 
-				&lt;/object ID/object instance ID/resoure ID&gt;, for example:/10322/2/4]]></Description>
+				'</object ID/object instance ID/resoure ID>', for example:/10322/2/4]]></Description>
 		</Item>
 		<Item ID="3">
 			<Name>High Threshold</Name>

--- a/version_history/10334-1_0.xml
+++ b/version_history/10334-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: &lt;/10320/2&gt;.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Probable Cause</Name>

--- a/version_history/10334-1_0.xml
+++ b/version_history/10334-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2 >.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Probable Cause</Name>

--- a/version_history/10334-1_0.xml
+++ b/version_history/10334-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2 >.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: </10320/2>.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Probable Cause</Name>

--- a/version_history/10335-1_0.xml
+++ b/version_history/10335-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2 >.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Event Type</Name>

--- a/version_history/10335-1_0.xml
+++ b/version_history/10335-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: &lt;/10320/2&gt;.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: '</10320/2>'.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Event Type</Name>

--- a/version_history/10335-1_0.xml
+++ b/version_history/10335-1_0.xml
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<Type>String</Type>
 			<RangeEnumeration>4..63</RangeEnumeration>
 			<Units/>
-			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: < /10320/2 >.]]></Description>
+			<Description><![CDATA[Contains the object ID and object instance ID/name, for example: </10320/2>.]]></Description>
 		</Item>
 		<Item ID="2">
 			<Name>Event Type</Name>

--- a/version_history/18831-1_0.xml
+++ b/version_history/18831-1_0.xml
@@ -52,7 +52,7 @@ https://ioterop.com/
                 <Type>Corelnk</Type>
                 <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
-                <Description><![CDATA[The source of the data to publish (e.g. '< /sensors/temp>', or '< /3303/0/5700>;</3336/0>'). If this Resource is empty, the published data are implementation dependent.]]></Description>
+                <Description><![CDATA[The source of the data to publish (e.g. < /sensors/temp >, or < /3303/0/5700 >; < /3336/0 >). If this Resource is empty, the published data are implementation dependent.]]></Description>
             </Item>
             <Item ID="1">
                 <Name>Broker</Name>

--- a/version_history/18831-1_0.xml
+++ b/version_history/18831-1_0.xml
@@ -52,7 +52,7 @@ https://ioterop.com/
                 <Type>Corelnk</Type>
                 <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
-                <Description><![CDATA[The source of the data to publish (e.g. "</sensors/temp>", or "</3303/0/5700>;</3336/0>"). If this Resource is empty, the published data are implementation dependent.]]></Description>
+                <Description><![CDATA[The source of the data to publish (e.g. '< /sensors/temp>', or '< /3303/0/5700>;</3336/0>'). If this Resource is empty, the published data are implementation dependent.]]></Description>
             </Item>
             <Item ID="1">
                 <Name>Broker</Name>

--- a/version_history/18831-1_0.xml
+++ b/version_history/18831-1_0.xml
@@ -52,7 +52,7 @@ https://ioterop.com/
                 <Type>Corelnk</Type>
                 <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
-                <Description><![CDATA[The source of the data to publish (e.g. < /sensors/temp >, or < /3303/0/5700 >; < /3336/0 >). If this Resource is empty, the published data are implementation dependent.]]></Description>
+                <Description><![CDATA[The source of the data to publish (e.g. </sensors/temp>, or </3303/0/5700>; </3336/0>). If this Resource is empty, the published data are implementation dependent.]]></Description>
             </Item>
             <Item ID="1">
                 <Name>Broker</Name>


### PR DESCRIPTION
This PR resolves the issue raised by PR #558.
The LwM2M Editor tool has been updated and now it renders the use of angular brackets inside of the CDATA correctly.