### PR TITLE
[Admin] Spelling error corrected 5853 updated

### DIFF
--- a/3306.xml
+++ b/3306.xml
@@ -73,7 +73,7 @@ POSSIBILITY OF SUCH DAMAGE.
 				<Description>The time in seconds that the device has been on. Writing a value of 0 resets the counter.</Description>
 			</Item>
 			<Item ID="5853">
-				<Name>Muti-state Output</Name>
+				<Name>Multi-state Output</Name>
 				<Operations>RW</Operations>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>

--- a/Common.xml
+++ b/Common.xml
@@ -2267,7 +2267,7 @@
 
         <Item ID="5853">
 
-        <Name>Muti-state Output</Name>
+        <Name>Multi-state Output</Name>
 
         <Operations>RW</Operations>
 

--- a/version_history/3306-1_0.xml
+++ b/version_history/3306-1_0.xml
@@ -73,7 +73,7 @@ POSSIBILITY OF SUCH DAMAGE.
 				<Description>The time in seconds that the device has been on. Writing a value of 0 resets the counter.</Description>
 			</Item>
 			<Item ID="5853">
-				<Name>Muti-state Output</Name>
+				<Name>Multi-state Output</Name>
 				<Operations>RW</Operations>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>

--- a/version_history/3306-1_1.xml
+++ b/version_history/3306-1_1.xml
@@ -73,7 +73,7 @@ POSSIBILITY OF SUCH DAMAGE.
 				<Description>The time in seconds that the device has been on. Writing a value of 0 resets the counter.</Description>
 			</Item>
 			<Item ID="5853">
-				<Name>Muti-state Output</Name>
+				<Name>Multi-state Output</Name>
 				<Operations>RW</Operations>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>


### PR DESCRIPTION
Spelling error corrected in RR 5853 `muti-state `to `multi-state`
Effects 1 Object - 3306

Resolves Issue https://github.com/OpenMobileAlliance/lwm2m-registry/issues/577
