### PR TITLE
[AVSystem] [Modbus] Add definitions of objects 10374 and 10375

### DIFF
--- a/10374.xml
+++ b/10374.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?><!--Copyright 2021 AVSystem.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/LWM2M.xsd">
+	<Object ObjectType="MODefinition">
+		<Name>Modbus Connection</Name>
+		<Description1><![CDATA[This LwM2M Object is used to configure a Modbus protocol connection.]]></Description1>
+		<ObjectID>10374</ObjectID>
+		<ObjectURN>urn:oma:lwm2m:x:10374</ObjectURN>
+		<LWM2MVersion>1.0</LWM2MVersion>
+		<ObjectVersion>1.0</ObjectVersion>
+		<MultipleInstances>Multiple</MultipleInstances>
+		<Mandatory>Optional</Mandatory>
+		<Resources>
+			<Item ID="0">
+				<Name>Address</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Address uniquely defining the Modbus connection within a given physical layer. The LwM2M Client is assumed to take the role of a Modbus client.
+For Modbus TCP, this is a hostname with optional port number, e.g. "10.11.12.13" or "example.com:502". Port number 502 is the default if not specified.
+For Modbus RTU, this is an implementation-defined unique identifier of a physical port. Suggested formats are UNIX-style device names (e.g. "/dev/tty1") or DOS-style port designations (e.g. "COM2"), but any strings may be used. Values that are valid for this LwM2M Client are listed in the "Available RTU ports" resource. The Client MAY treat configuration as invalid if Physical Layer Type is set to Modbus RTU and the Address is not equal to any of the "Available RTU ports".]]></Description>
+			</Item>
+			<Item ID="1">
+				<Name>Physical Layer Type</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..2</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Type of the physical layer to use for this connection.
+0: Modbus TCP
+1: Modbus RTU (RS-232)
+2: Modbus RTU (RS-485)
+Additional types MAY be specified in future revisions of this object.]]></Description>
+			</Item>
+			<Item ID="2">
+				<Name>Enable</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Boolean</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Enables or disables this Modbus connection.
+When set to false, this Modbus connection is administratively disabled and shall not function. Upon setting it to true, the LwM2M Client shall attempt opening the relevant connection and report the result of that operation in the "State" resource.]]></Description>
+			</Item>
+			<Item ID="3">
+				<Name>Baudrate</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units>bit/s</Units>
+				<Description><![CDATA[Baudrate for the RTU link layer, e.g. 9600, 115200, etc.
+NOTE: 8 data bits are always used.
+Mandatory if Physical Layer Type is set to Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="4">
+				<Name>Stop Bits</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>1..2</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Number of stop bits to use for the RTU link layer.
+Mandatory if Physical Layer Type is set to Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="5">
+				<Name>Parity</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..2</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Parity bit type to use for the RTU link layer.
+0: none
+1: even
+2: odd
+Mandatory if Physical Layer Type is set to Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="6">
+				<Name>Hardware Control Flow Mode</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..2</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Type of hardware flow control to use for the RTU link layer.
+0: none
+1: Set RTS flag when sending data
+2: Set RTS flag when NOT sending data
+Mandatory if Physical Layer Type is set to Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="7">
+				<Name>Available RTU Ports</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[List of all valid values for the "Address" resource when Physical Layer Type is set to Modbus RTU. The Resource Instance IDs shall have no semantic meaning. The value of this resource shall be equal for all instances of this Object.
+Mandatory if this LwM2M Client has at least one physical port usable for Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="8">
+				<Name>State</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..4</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[State of this Modbus connection.
+0: disabled (MUST NOT be used unless the "Enable" resource is set to false)
+1: connecting
+2: successfully connected
+3: invalid or unsupported configuration
+4: connection error
+If this resource reached the "connection error" state after having been successfully connected previously, the LwM2M Client SHOULD apply an implementation-specific deferred retry policy to try establishing the connection again.
+If the resource reached the "connection error" state as a direct result of setting the "Enable" resource to true or changing the configuration while in the enabled state, the LwM2M Client MAY apply an implementation-specific deferred retry policy to try establishing the connection again, or it MAY stay in the "connection error" state until further reconfiguration by the LwM2M Server.
+NOTE: The "connection error" state corresponds to any non-specific failure case. More specific error cases MAY be specified in future revisions of this object. LwM2M Server SHOULD interpret any unknown or invalid value reported by the LwM2M Client as equivalent to "connection error".]]></Description>
+			</Item>
+		</Resources>
+		<Description2><![CDATA[]]></Description2>
+	</Object>
+</LWM2M>

--- a/10375.xml
+++ b/10375.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?><!--Copyright 2021 AVSystem.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/LWM2M.xsd">
+	<Object ObjectType="MODefinition">
+		<Name>Modbus Register Cluster</Name>
+		<Description1><![CDATA[This LwM2M Object represents a set of Modbus registers and acts as an interface to read and write their values.]]></Description1>
+		<ObjectID>10375</ObjectID>
+		<ObjectURN>urn:oma:lwm2m:x:10375</ObjectURN>
+		<LWM2MVersion>1.0</LWM2MVersion>
+		<ObjectVersion>1.0</ObjectVersion>
+		<MultipleInstances>Multiple</MultipleInstances>
+		<Mandatory>Optional</Mandatory>
+		<Resources>
+			<Item ID="0">
+				<Name>Connection</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Objlnk</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Link to an instance of the "Modbus Connection" object to use.]]></Description>
+			</Item>
+			<Item ID="1">
+				<Name>Register Type</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>1..4</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Type of Modbus objects to access.
+1: Coil
+2: Discrete Input
+3: Holding Register
+4: Input Register
+Note: For convenience, the values are equal to function codes corresponding to Modbus "read" operations for each object type.]]></Description>
+			</Item>
+			<Item ID="2">
+				<Name>Unit ID</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..247, 255</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Server unit ID that this register cluster addresses.
+Special non-significant value of 255 is valid only for Modbus TCP connections.]]></Description>
+			</Item>
+			<Item ID="3">
+				<Name>Starting Register Address</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..65535</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Address of the first register that this register cluster addresses.]]></Description>
+			</Item>
+			<Item ID="4">
+				<Name>Quantity of Registers</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>1..2000</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Number of registers in this register cluster.
+If the Register Type is Holding Register or Input Register, the valid range for this resource is 1..125. Larger values are only supported for Coils and Discrete Inputs.
+If this resource is not present, the default value of 1 is assumed.]]></Description>
+			</Item>
+			<Item ID="5">
+				<Name>Values</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..65535</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[List of values of the registers addressed by this register cluster.
+The Resource Instance IDs shall range from 0 to "Quantity of Registers - 1" (note: absolute register address cannot be used, because 65535 is a valid Modbus register ID, but not a valid LwM2M Resource Instance ID).
+When the Register Type is Coil or Discrete Input, "0" and "1" are the only valid values for each of the Resource Instances.
+When the Register Type is Discrete Input or Input Register, this resource shall behave as a read-only resource, i.e. as if the "Operations" attribute was "R".
+Even if the Register Type is Coil or Holding Register, any write operation that would result in the set of valid Resource Instance IDs being changed, shall result in a Bad Request error.]]></Description>
+			</Item>
+			<Item ID="6">
+				<Name>Minimum Measured Values</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..65535</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Minimum values recorded by each of the registers in this cluster.
+If this resource is supported, the Resource Instance IDs shall range from 0 to "Quantity of Registers - 1". Each Resource Instance shall hold the minimum value recorded by the corresponding Resource Instance of the "Values" resource since the configuration of this cluster (resources 0-4) has been last changed, or since the "Reset Minimum and Maximum Measured Values" resource has been last executed, whichever was later.]]></Description>
+			</Item>
+			<Item ID="7">
+				<Name>Maximum Measured Values</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..65535</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Maximum values recorded by each of the registers in this cluster.
+If this resource is supported, the Resource Instance IDs shall range from 0 to "Quantity of Registers - 1". Each Resource Instance shall hold the maximum value recorded by the corresponding Resource Instance of the "Values" resource since the configuration of this cluster (resources 0-4) has been last changed, or since the "Reset Minimum and Maximum Measured Values" resource has been last executed, whichever was later.]]></Description>
+			</Item>
+			<Item ID="8">
+				<Name>Reset Minimum and Maximum Measured Values</Name>
+				<Operations>E</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type></Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Resets the "Minimum Measured Values" and "Maximum Measured Values" resources.]]></Description>
+			</Item>
+		</Resources>
+		<Description2><![CDATA[]]></Description2>
+	</Object>
+</LWM2M>

--- a/DDF.xml
+++ b/DDF.xml
@@ -5457,11 +5457,11 @@ Instances of this Object are linked from Instances of Object 0 using the OSCORE 
         <ObjectID>10374</ObjectID>
         <URN>urn:oma:lwm2m:x:10374</URN>
         <Name>Modbus Connection</Name>
-        <Description>This LwM2M Object is used to configure a Modbus protocol connection</Description>
+        <Description>This LwM2M Object is used to configure a Modbus protocol connection.</Description>
         <Owner>AVSystem</Owner>
         <Source>2</Source>
         <Ver>1.0</Ver>
-        <DDF></DDF>
+        <DDF>10374.xml</DDF>
         <Vorto></Vorto>
         <DDFLink>1</DDFLink>
         <TS></TS>
@@ -5475,7 +5475,7 @@ Instances of this Object are linked from Instances of Object 0 using the OSCORE 
         <Owner>AVSystem</Owner>
         <Source>2</Source>
         <Ver>1.0</Ver>
-        <DDF></DDF>
+        <DDF>10375.xml</DDF>
         <Vorto></Vorto>
         <DDFLink>1</DDFLink>
         <TS></TS>

--- a/version_history/10374-1_0.xml
+++ b/version_history/10374-1_0.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?><!--Copyright 2021 AVSystem.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/LWM2M.xsd">
+	<Object ObjectType="MODefinition">
+		<Name>Modbus Connection</Name>
+		<Description1><![CDATA[This LwM2M Object is used to configure a Modbus protocol connection.]]></Description1>
+		<ObjectID>10374</ObjectID>
+		<ObjectURN>urn:oma:lwm2m:x:10374</ObjectURN>
+		<LWM2MVersion>1.0</LWM2MVersion>
+		<ObjectVersion>1.0</ObjectVersion>
+		<MultipleInstances>Multiple</MultipleInstances>
+		<Mandatory>Optional</Mandatory>
+		<Resources>
+			<Item ID="0">
+				<Name>Address</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Address uniquely defining the Modbus connection within a given physical layer. The LwM2M Client is assumed to take the role of a Modbus client.
+For Modbus TCP, this is a hostname with optional port number, e.g. "10.11.12.13" or "example.com:502". Port number 502 is the default if not specified.
+For Modbus RTU, this is an implementation-defined unique identifier of a physical port. Suggested formats are UNIX-style device names (e.g. "/dev/tty1") or DOS-style port designations (e.g. "COM2"), but any strings may be used. Values that are valid for this LwM2M Client are listed in the "Available RTU ports" resource. The Client MAY treat configuration as invalid if Physical Layer Type is set to Modbus RTU and the Address is not equal to any of the "Available RTU ports".]]></Description>
+			</Item>
+			<Item ID="1">
+				<Name>Physical Layer Type</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..2</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Type of the physical layer to use for this connection.
+0: Modbus TCP
+1: Modbus RTU (RS-232)
+2: Modbus RTU (RS-485)
+Additional types MAY be specified in future revisions of this object.]]></Description>
+			</Item>
+			<Item ID="2">
+				<Name>Enable</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Boolean</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Enables or disables this Modbus connection.
+When set to false, this Modbus connection is administratively disabled and shall not function. Upon setting it to true, the LwM2M Client shall attempt opening the relevant connection and report the result of that operation in the "State" resource.]]></Description>
+			</Item>
+			<Item ID="3">
+				<Name>Baudrate</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units>bit/s</Units>
+				<Description><![CDATA[Baudrate for the RTU link layer, e.g. 9600, 115200, etc.
+NOTE: 8 data bits are always used.
+Mandatory if Physical Layer Type is set to Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="4">
+				<Name>Stop Bits</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>1..2</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Number of stop bits to use for the RTU link layer.
+Mandatory if Physical Layer Type is set to Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="5">
+				<Name>Parity</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..2</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Parity bit type to use for the RTU link layer.
+0: none
+1: even
+2: odd
+Mandatory if Physical Layer Type is set to Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="6">
+				<Name>Hardware Control Flow Mode</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..2</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Type of hardware flow control to use for the RTU link layer.
+0: none
+1: Set RTS flag when sending data
+2: Set RTS flag when NOT sending data
+Mandatory if Physical Layer Type is set to Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="7">
+				<Name>Available RTU Ports</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[List of all valid values for the "Address" resource when Physical Layer Type is set to Modbus RTU. The Resource Instance IDs shall have no semantic meaning. The value of this resource shall be equal for all instances of this Object.
+Mandatory if this LwM2M Client has at least one physical port usable for Modbus RTU.]]></Description>
+			</Item>
+			<Item ID="8">
+				<Name>State</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..4</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[State of this Modbus connection.
+0: disabled (MUST NOT be used unless the "Enable" resource is set to false)
+1: connecting
+2: successfully connected
+3: invalid or unsupported configuration
+4: connection error
+If this resource reached the "connection error" state after having been successfully connected previously, the LwM2M Client SHOULD apply an implementation-specific deferred retry policy to try establishing the connection again.
+If the resource reached the "connection error" state as a direct result of setting the "Enable" resource to true or changing the configuration while in the enabled state, the LwM2M Client MAY apply an implementation-specific deferred retry policy to try establishing the connection again, or it MAY stay in the "connection error" state until further reconfiguration by the LwM2M Server.
+NOTE: The "connection error" state corresponds to any non-specific failure case. More specific error cases MAY be specified in future revisions of this object. LwM2M Server SHOULD interpret any unknown or invalid value reported by the LwM2M Client as equivalent to "connection error".]]></Description>
+			</Item>
+		</Resources>
+		<Description2><![CDATA[]]></Description2>
+	</Object>
+</LWM2M>

--- a/version_history/10375-1_0.xml
+++ b/version_history/10375-1_0.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?><!--Copyright 2021 AVSystem.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/LWM2M.xsd">
+	<Object ObjectType="MODefinition">
+		<Name>Modbus Register Cluster</Name>
+		<Description1><![CDATA[This LwM2M Object represents a set of Modbus registers and acts as an interface to read and write their values.]]></Description1>
+		<ObjectID>10375</ObjectID>
+		<ObjectURN>urn:oma:lwm2m:x:10375</ObjectURN>
+		<LWM2MVersion>1.0</LWM2MVersion>
+		<ObjectVersion>1.0</ObjectVersion>
+		<MultipleInstances>Multiple</MultipleInstances>
+		<Mandatory>Optional</Mandatory>
+		<Resources>
+			<Item ID="0">
+				<Name>Connection</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Objlnk</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Link to an instance of the "Modbus Connection" object to use.]]></Description>
+			</Item>
+			<Item ID="1">
+				<Name>Register Type</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>1..4</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Type of Modbus objects to access.
+1: Coil
+2: Discrete Input
+3: Holding Register
+4: Input Register
+Note: For convenience, the values are equal to function codes corresponding to Modbus "read" operations for each object type.]]></Description>
+			</Item>
+			<Item ID="2">
+				<Name>Unit ID</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..247, 255</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Server unit ID that this register cluster addresses.
+Special non-significant value of 255 is valid only for Modbus TCP connections.]]></Description>
+			</Item>
+			<Item ID="3">
+				<Name>Starting Register Address</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..65535</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Address of the first register that this register cluster addresses.]]></Description>
+			</Item>
+			<Item ID="4">
+				<Name>Quantity of Registers</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>1..2000</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Number of registers in this register cluster.
+If the Register Type is Holding Register or Input Register, the valid range for this resource is 1..125. Larger values are only supported for Coils and Discrete Inputs.
+If this resource is not present, the default value of 1 is assumed.]]></Description>
+			</Item>
+			<Item ID="5">
+				<Name>Values</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..65535</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[List of values of the registers addressed by this register cluster.
+The Resource Instance IDs shall range from 0 to "Quantity of Registers - 1" (note: absolute register address cannot be used, because 65535 is a valid Modbus register ID, but not a valid LwM2M Resource Instance ID).
+When the Register Type is Coil or Discrete Input, "0" and "1" are the only valid values for each of the Resource Instances.
+When the Register Type is Discrete Input or Input Register, this resource shall behave as a read-only resource, i.e. as if the "Operations" attribute was "R".
+Even if the Register Type is Coil or Holding Register, any write operation that would result in the set of valid Resource Instance IDs being changed, shall result in a Bad Request error.]]></Description>
+			</Item>
+			<Item ID="6">
+				<Name>Minimum Measured Values</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..65535</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Minimum values recorded by each of the registers in this cluster.
+If this resource is supported, the Resource Instance IDs shall range from 0 to "Quantity of Registers - 1". Each Resource Instance shall hold the minimum value recorded by the corresponding Resource Instance of the "Values" resource since the configuration of this cluster (resources 0-4) has been last changed, or since the "Reset Minimum and Maximum Measured Values" resource has been last executed, whichever was later.]]></Description>
+			</Item>
+			<Item ID="7">
+				<Name>Maximum Measured Values</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..65535</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Maximum values recorded by each of the registers in this cluster.
+If this resource is supported, the Resource Instance IDs shall range from 0 to "Quantity of Registers - 1". Each Resource Instance shall hold the maximum value recorded by the corresponding Resource Instance of the "Values" resource since the configuration of this cluster (resources 0-4) has been last changed, or since the "Reset Minimum and Maximum Measured Values" resource has been last executed, whichever was later.]]></Description>
+			</Item>
+			<Item ID="8">
+				<Name>Reset Minimum and Maximum Measured Values</Name>
+				<Operations>E</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type></Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Resets the "Minimum Measured Values" and "Maximum Measured Values" resources.]]></Description>
+			</Item>
+		</Resources>
+		<Description2><![CDATA[]]></Description2>
+	</Object>
+</LWM2M>


### PR DESCRIPTION
This contains the implementation of objects requested in issue #635.

The objects are identical to the preview previously posted in the issue, just with final object IDs and updated URNs.