### PR TITLE
Add  LWM2M v1.1 Test Object (ID:3442)

### DIFF
--- a/3442.xml
+++ b/3442.xml
@@ -32,8 +32,8 @@ POSSIBILITY OF SUCH DAMAGE.
     <Object ObjectType="MODefinition">
         <Name>LwM2M v1.0 Test Object</Name>
         <Description1><![CDATA[This object aims to make easier to do interoperability tests about LWM2M v1.0. It contains resources for each available datatype.]]></Description1>
-        <ObjectID>3441</ObjectID>
-        <ObjectURN>urn:oma:lwm2m:ext:3441</ObjectURN>
+        <ObjectID>3442</ObjectID>
+        <ObjectURN>urn:oma:lwm2m:ext:3442</ObjectURN>
         <LWM2MVersion>1.0</LWM2MVersion>
         <ObjectVersion>1.0</ObjectVersion>
         <MultipleInstances>Multiple</MultipleInstances>

--- a/3442.xml
+++ b/3442.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- BSD-3 Clause License 
+
+    Copyright 2021 Eclipse Foundation.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://openmobilealliance.org/tech/profiles/LWM2M.xsd">
+    <Object ObjectType="MODefinition">
+        <Name>LwM2M v1.0 Test Object</Name>
+        <Description1><![CDATA[This object aims to make easier to do interoperability tests about LWM2M v1.0. It contains resources for each available datatype.]]></Description1>
+        <ObjectID>3441</ObjectID>
+        <ObjectURN>urn:oma:lwm2m:ext:3441</ObjectURN>
+        <LWM2MVersion>1.0</LWM2MVersion>
+        <ObjectVersion>1.0</ObjectVersion>
+        <MultipleInstances>Multiple</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Resources>
+            <Item ID="0">
+                <Name>Reset values</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Reset all resources of this object with their initial value.</Description>
+            </Item>
+            <Item ID="1">
+                <Name>Randomize values</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>
+<![CDATA[Set random value to all resources. For multi-instance resources, the number of resource instances is also randomized.
+Randomization should avoid to generate too big payload. We advice to limit value to something like : 
+ - 20 characters for String,
+ - 20 bytes for Opaque,
+ - 10 instances for multi-instance resources. 
+]]>
+                </Description>
+            </Item>
+            <Item ID="2">
+                <Name>Clear values</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>
+<![CDATA[Clear all values : 
+ - all multiple resource as empty resource
+ - all number to 0
+ - String to empty string
+ - boolean to false,
+ - opaque to empty byte array,
+ - time to an 1st, 1970 in the UTC time zone
+ - objlink to null link]]>
+                </Description>
+            </Item>
+            <Item ID="3">
+                <Name>Exec With Arguments</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>
+<![CDATA[This resources can be used to test "Execute Operation" with Arguments.
+Sent Arguments can be read via "Arguments List"(4) resource.
+E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
+     then /3441/0/4/3 will be 'stringValue' and /3441/0/4/4 will be an empty string.
+]]>
+                </Description>
+            </Item>
+            <Item ID="4">
+                <Name>Arguments List</Name>
+                <Operations>R</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>List of Arguments from last execute on "Exec With Arguments"(3) resource. This resource is not affected by "Randomize values"(1) executable resource.
+                </Description>
+            </Item>
+            <Item ID="110">
+                <Name>String Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be "initial value".
+                </Description>
+            </Item>
+            <Item ID="120">
+                <Name>Integer Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Integer</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be "1024".
+                </Description>
+            </Item>
+            <Item ID="130">
+                <Name>Float Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Float</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be "3.14159".
+                </Description>
+            </Item>
+            <Item ID="140">
+                <Name>Boolean Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Boolean</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be "true".</Description>
+            </Item>
+            <Item ID="150">
+                <Name>Opaque Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Opaque</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be the bytes sequence "0123456789ABCDEF" (Hexadecimal notation).
+                </Description>
+            </Item>
+            <Item ID="160">
+                <Name>Time Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Time</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be the time to an 1st, 2000 in the UTC time zone. (Timestamp value : 946684800)</Description>
+            </Item>
+            <Item ID="170">
+                <Name>ObjLink Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Objlnk</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be a link to instance 0 of Device Object 3 (3:0).</Description>
+            </Item>
+            <Item ID="1110">
+                <Name>Multiple String Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "initial value".</Description>
+            </Item>
+            <Item ID="1120">
+                <Name>Multiple Integer Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Integer</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "1024".</Description>
+            </Item>
+            <Item ID="1130">
+                <Name>Multiple Float Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Float</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "3.14159".</Description>
+            </Item>
+            <Item ID="1140">
+                <Name>Multiple Boolean Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Boolean</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "true".</Description>
+            </Item>
+            <Item ID="1150">
+                <Name>Multiple Opaque Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Opaque</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "0123456789ABCDEF"(Hexadecimal notation of the bytes sequence).</Description>
+            </Item>
+            <Item ID="1160">
+                <Name>Multiple Time Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Time</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value 1st, 2000 in the UTC time zone (Timestamp value : 946684800).</Description>
+            </Item>
+            <Item ID="1170">
+                <Name>Multiple ObjLink Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Objlnk</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "3:0".</Description>
+            </Item>
+        </Resources>
+        <Description2></Description2>
+    </Object>
+</LWM2M>

--- a/3442.xml
+++ b/3442.xml
@@ -28,13 +28,13 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 -->
 <LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://openmobilealliance.org/tech/profiles/LWM2M.xsd">
+    xsi:noNamespaceSchemaLocation="http://openmobilealliance.org/tech/profiles/LWM2M-v1_1.xsd">
     <Object ObjectType="MODefinition">
-        <Name>LwM2M v1.0 Test Object</Name>
-        <Description1><![CDATA[This object aims to make easier to do interoperability tests about LWM2M v1.0. It contains resources for each available datatype.]]></Description1>
+        <Name>LwM2M v1.1 Test Object</Name>
+        <Description1><![CDATA[This object aims to make easier to do interoperability tests about LWM2M v1.1. It contains resources for each available datatype.]]></Description1>
         <ObjectID>3442</ObjectID>
         <ObjectURN>urn:oma:lwm2m:ext:3442</ObjectURN>
-        <LWM2MVersion>1.0</LWM2MVersion>
+        <LWM2MVersion>1.1</LWM2MVersion>
         <ObjectVersion>1.0</ObjectVersion>
         <MultipleInstances>Multiple</MultipleInstances>
         <Mandatory>Optional</Mandatory>

--- a/3442.xml
+++ b/3442.xml
@@ -134,6 +134,17 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <Description>Initial value must be "1024".
                 </Description>
             </Item>
+            <Item ID="125">
+                <Name>Unsigned Integer Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Unsigned Integer</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 2^63 (9223372036854775808).
+                </Description>
+            </Item>
             <Item ID="130">
                 <Name>Float Value</Name>
                 <Operations>RW</Operations>
@@ -186,6 +197,16 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <Units />
                 <Description>Initial value must be a link to instance 0 of Device Object 3 (3:0).</Description>
             </Item>
+            <Item ID="180">
+                <Name>CoreLnk Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Corelnk</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description><![CDATA[Initial value must be a the "</3442>".]]></Description>
+            </Item>
             <Item ID="1110">
                 <Name>Multiple String Value</Name>
                 <Operations>RW</Operations>
@@ -205,6 +226,17 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <RangeEnumeration />
                 <Units />
                 <Description>Initial value must be 1 instance with ID 0 and value "1024".</Description>
+            </Item>
+            <Item ID="1125">
+                <Name>Multiple Unsigned Integer Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Unsigned Integer</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value 2^63 (9223372036854775808).
+                </Description>
             </Item>
             <Item ID="1130">
                 <Name>Multiple Float Value</Name>
@@ -255,6 +287,16 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <RangeEnumeration />
                 <Units />
                 <Description>Initial value must be 1 instance with ID 0 and value "3:0".</Description>
+            </Item>
+             <Item ID="1180">
+                <Name>Multiple CoreLnk Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Corelnk</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description><![CDATA[Initial value must be 1 instance with ID 0 and value "</3442>".]]></Description>
             </Item>
         </Resources>
         <Description2></Description2>

--- a/3442.xml
+++ b/3442.xml
@@ -112,6 +112,34 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <Description>List of Arguments from last execute on "Exec With Arguments"(3) resource. This resource is not affected by "Randomize values"(1) executable resource.
                 </Description>
             </Item>
+            <Item ID="5">
+                <Name>Send Data</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>
+<![CDATA[This resources can be used to test "Send Operation".
+When LWM2M client received the Execute Request, it must send data for each resources listed in "Resources to Send"(6) resource.
+By default LWM2M client chooses the Content format and Timeout to use for this Send Request, but Arguments can optionally be used to change it.
+Argument 0 must contain the Content Format code. e.g. 0='110' for SENML_JSON.
+Argument 1 must contain the request timeout in ms. e.g. 1='2000' for 2s timeout.
+]]>
+               </Description>
+            </Item>
+            <Item ID="6">
+                <Name>Resources to Send</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>List of path to LWM2M node (Object / Object Instance / Resource / Resource Instance) used by "Send Data "(5) resource. This resource is not affected by "Randomize values"(1) executable resource.
+                </Description>
+            </Item>
             <Item ID="110">
                 <Name>String Value</Name>
                 <Operations>RW</Operations>

--- a/DDF.xml
+++ b/DDF.xml
@@ -3682,12 +3682,12 @@ Instances of this Object are linked from Instances of Object 0 using the OSCORE 
     <Item>
         <ObjectID>3442</ObjectID>
         <URN>urn:oma:lwm2m:ext:3442</URN>
-        <Name>TBD</Name>
-        <Description>TBD</Description>
-        <Owner>TBD</Owner>
+        <Name>LwM2M v1.1 Test Object</Name>
+        <Description>This object aims to make easier to do interoperability tests about LWM2M v1.1. It contains resources for each available datatype.</Description>
+        <Owner>Eclipse Foundation</Owner>
         <Source>1</Source>
         <Ver>1.0</Ver>
-        <DDF></DDF>
+        <DDF>3442.xml</DDF>
         <Vorto></Vorto>
         <DDFLink>1</DDFLink>
         <TS></TS>

--- a/DDF.xml
+++ b/DDF.xml
@@ -3703,7 +3703,7 @@ Instances of this Object are linked from Instances of Object 0 using the OSCORE 
         <Ver>1.0</Ver>
         <DDF></DDF>
         <Vorto></Vorto>
-        <DDFLink>1</DDFLink>
+        <DDFLink>0</DDFLink>
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>

--- a/version_history/3442-1_0.xml
+++ b/version_history/3442-1_0.xml
@@ -134,6 +134,17 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <Description>Initial value must be "1024".
                 </Description>
             </Item>
+            <Item ID="125">
+                <Name>Unsigned Integer Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Unsigned Integer</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 2^63 (9223372036854775808).
+                </Description>
+            </Item>
             <Item ID="130">
                 <Name>Float Value</Name>
                 <Operations>RW</Operations>
@@ -186,6 +197,16 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <Units />
                 <Description>Initial value must be a link to instance 0 of Device Object 3 (3:0).</Description>
             </Item>
+            <Item ID="180">
+                <Name>CoreLnk Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Corelnk</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description><![CDATA[Initial value must be a the "</3342>".]]></Description>
+            </Item>
             <Item ID="1110">
                 <Name>Multiple String Value</Name>
                 <Operations>RW</Operations>
@@ -205,6 +226,17 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <RangeEnumeration />
                 <Units />
                 <Description>Initial value must be 1 instance with ID 0 and value "1024".</Description>
+            </Item>
+            <Item ID="1125">
+                <Name>Multiple Unsigned Integer Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Unsigned Integer</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value 2^63 (9223372036854775808).
+                </Description>
             </Item>
             <Item ID="1130">
                 <Name>Multiple Float Value</Name>
@@ -255,6 +287,16 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <RangeEnumeration />
                 <Units />
                 <Description>Initial value must be 1 instance with ID 0 and value "3:0".</Description>
+            </Item>
+             <Item ID="1180">
+                <Name>Multiple CoreLnk Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Corelnk</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description><![CDATA[Initial value must be 1 instance with ID 0 and value "</3342>".]]></Description>
             </Item>
         </Resources>
         <Description2></Description2>

--- a/version_history/3442-1_0.xml
+++ b/version_history/3442-1_0.xml
@@ -32,8 +32,8 @@ POSSIBILITY OF SUCH DAMAGE.
     <Object ObjectType="MODefinition">
         <Name>LwM2M v1.0 Test Object</Name>
         <Description1><![CDATA[This object aims to make easier to do interoperability tests about LWM2M v1.0. It contains resources for each available datatype.]]></Description1>
-        <ObjectID>3441</ObjectID>
-        <ObjectURN>urn:oma:lwm2m:ext:3441</ObjectURN>
+        <ObjectID>3442</ObjectID>
+        <ObjectURN>urn:oma:lwm2m:ext:3442</ObjectURN>
         <LWM2MVersion>1.0</LWM2MVersion>
         <ObjectVersion>1.0</ObjectVersion>
         <MultipleInstances>Multiple</MultipleInstances>

--- a/version_history/3442-1_0.xml
+++ b/version_history/3442-1_0.xml
@@ -233,7 +233,7 @@ Argument 1 must contain the request timeout in ms. e.g. 1='2000' for 2s timeout.
                 <Type>Corelnk</Type>
                 <RangeEnumeration />
                 <Units />
-                <Description><![CDATA[Initial value must be a the "</3342>".]]></Description>
+                <Description><![CDATA[Initial value must be a the "</3442>".]]></Description>
             </Item>
             <Item ID="1110">
                 <Name>Multiple String Value</Name>
@@ -324,7 +324,7 @@ Argument 1 must contain the request timeout in ms. e.g. 1='2000' for 2s timeout.
                 <Type>Corelnk</Type>
                 <RangeEnumeration />
                 <Units />
-                <Description><![CDATA[Initial value must be 1 instance with ID 0 and value "</3342>".]]></Description>
+                <Description><![CDATA[Initial value must be 1 instance with ID 0 and value "</3442>".]]></Description>
             </Item>
         </Resources>
         <Description2></Description2>

--- a/version_history/3442-1_0.xml
+++ b/version_history/3442-1_0.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- BSD-3 Clause License 
+
+    Copyright 2021 Eclipse Foundation.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://openmobilealliance.org/tech/profiles/LWM2M.xsd">
+    <Object ObjectType="MODefinition">
+        <Name>LwM2M v1.0 Test Object</Name>
+        <Description1><![CDATA[This object aims to make easier to do interoperability tests about LWM2M v1.0. It contains resources for each available datatype.]]></Description1>
+        <ObjectID>3441</ObjectID>
+        <ObjectURN>urn:oma:lwm2m:ext:3441</ObjectURN>
+        <LWM2MVersion>1.0</LWM2MVersion>
+        <ObjectVersion>1.0</ObjectVersion>
+        <MultipleInstances>Multiple</MultipleInstances>
+        <Mandatory>Optional</Mandatory>
+        <Resources>
+            <Item ID="0">
+                <Name>Reset values</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Reset all resources of this object with their initial value.</Description>
+            </Item>
+            <Item ID="1">
+                <Name>Randomize values</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>
+<![CDATA[Set random value to all resources. For multi-instance resources, the number of resource instances is also randomized.
+Randomization should avoid to generate too big payload. We advice to limit value to something like : 
+ - 20 characters for String,
+ - 20 bytes for Opaque,
+ - 10 instances for multi-instance resources. 
+]]>
+                </Description>
+            </Item>
+            <Item ID="2">
+                <Name>Clear values</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>
+<![CDATA[Clear all values : 
+ - all multiple resource as empty resource
+ - all number to 0
+ - String to empty string
+ - boolean to false,
+ - opaque to empty byte array,
+ - time to an 1st, 1970 in the UTC time zone
+ - objlink to null link]]>
+                </Description>
+            </Item>
+            <Item ID="3">
+                <Name>Exec With Arguments</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>
+<![CDATA[This resources can be used to test "Execute Operation" with Arguments.
+Sent Arguments can be read via "Arguments List"(4) resource.
+E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
+     then /3441/0/4/3 will be 'stringValue' and /3441/0/4/4 will be an empty string.
+]]>
+                </Description>
+            </Item>
+            <Item ID="4">
+                <Name>Arguments List</Name>
+                <Operations>R</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>List of Arguments from last execute on "Exec With Arguments"(3) resource. This resource is not affected by "Randomize values"(1) executable resource.
+                </Description>
+            </Item>
+            <Item ID="110">
+                <Name>String Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be "initial value".
+                </Description>
+            </Item>
+            <Item ID="120">
+                <Name>Integer Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Integer</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be "1024".
+                </Description>
+            </Item>
+            <Item ID="130">
+                <Name>Float Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Float</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be "3.14159".
+                </Description>
+            </Item>
+            <Item ID="140">
+                <Name>Boolean Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Boolean</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be "true".</Description>
+            </Item>
+            <Item ID="150">
+                <Name>Opaque Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Opaque</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be the bytes sequence "0123456789ABCDEF" (Hexadecimal notation).
+                </Description>
+            </Item>
+            <Item ID="160">
+                <Name>Time Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Time</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be the time to an 1st, 2000 in the UTC time zone. (Timestamp value : 946684800)</Description>
+            </Item>
+            <Item ID="170">
+                <Name>ObjLink Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Objlnk</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be a link to instance 0 of Device Object 3 (3:0).</Description>
+            </Item>
+            <Item ID="1110">
+                <Name>Multiple String Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "initial value".</Description>
+            </Item>
+            <Item ID="1120">
+                <Name>Multiple Integer Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Integer</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "1024".</Description>
+            </Item>
+            <Item ID="1130">
+                <Name>Multiple Float Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Float</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "3.14159".</Description>
+            </Item>
+            <Item ID="1140">
+                <Name>Multiple Boolean Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Boolean</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "true".</Description>
+            </Item>
+            <Item ID="1150">
+                <Name>Multiple Opaque Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Opaque</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "0123456789ABCDEF"(Hexadecimal notation of the bytes sequence).</Description>
+            </Item>
+            <Item ID="1160">
+                <Name>Multiple Time Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Time</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value 1st, 2000 in the UTC time zone (Timestamp value : 946684800).</Description>
+            </Item>
+            <Item ID="1170">
+                <Name>Multiple ObjLink Value</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>Objlnk</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>Initial value must be 1 instance with ID 0 and value "3:0".</Description>
+            </Item>
+        </Resources>
+        <Description2></Description2>
+    </Object>
+</LWM2M>

--- a/version_history/3442-1_0.xml
+++ b/version_history/3442-1_0.xml
@@ -28,13 +28,13 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 -->
 <LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://openmobilealliance.org/tech/profiles/LWM2M.xsd">
+    xsi:noNamespaceSchemaLocation="http://openmobilealliance.org/tech/profiles/LWM2M-v1_1.xsd">
     <Object ObjectType="MODefinition">
-        <Name>LwM2M v1.0 Test Object</Name>
-        <Description1><![CDATA[This object aims to make easier to do interoperability tests about LWM2M v1.0. It contains resources for each available datatype.]]></Description1>
+        <Name>LwM2M v1.1 Test Object</Name>
+        <Description1><![CDATA[This object aims to make easier to do interoperability tests about LWM2M v1.1. It contains resources for each available datatype.]]></Description1>
         <ObjectID>3442</ObjectID>
         <ObjectURN>urn:oma:lwm2m:ext:3442</ObjectURN>
-        <LWM2MVersion>1.0</LWM2MVersion>
+        <LWM2MVersion>1.1</LWM2MVersion>
         <ObjectVersion>1.0</ObjectVersion>
         <MultipleInstances>Multiple</MultipleInstances>
         <Mandatory>Optional</Mandatory>

--- a/version_history/3442-1_0.xml
+++ b/version_history/3442-1_0.xml
@@ -112,6 +112,34 @@ E.g. If you send an Exec /3441/0/3 with "3='stringValue',4" as arguments value,
                 <Description>List of Arguments from last execute on "Exec With Arguments"(3) resource. This resource is not affected by "Randomize values"(1) executable resource.
                 </Description>
             </Item>
+            <Item ID="5">
+                <Name>Send Data</Name>
+                <Operations>E</Operations>
+                <MultipleInstances>Single</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type></Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>
+<![CDATA[This resources can be used to test "Send Operation".
+When LWM2M client received the Execute Request, it must send data for each resources listed in "Resources to Send"(6) resource.
+By default LWM2M client chooses the Content format and Timeout to use for this Send Request, but Arguments can optionally be used to change it.
+Argument 0 must contain the Content Format code. e.g. 0='110' for SENML_JSON.
+Argument 1 must contain the request timeout in ms. e.g. 1='2000' for 2s timeout.
+]]>
+               </Description>
+            </Item>
+            <Item ID="6">
+                <Name>Resources to Send</Name>
+                <Operations>RW</Operations>
+                <MultipleInstances>Multiple</MultipleInstances>
+                <Mandatory>Optional</Mandatory>
+                <Type>String</Type>
+                <RangeEnumeration />
+                <Units />
+                <Description>List of path to LWM2M node (Object / Object Instance / Resource / Resource Instance) used by "Send Data "(5) resource. This resource is not affected by "Randomize values"(1) executable resource.
+                </Description>
+            </Item>
             <Item ID="110">
                 <Name>String Value</Name>
                 <Operations>RW</Operations>


### PR DESCRIPTION
This aims to add Test Object for **LWM2M v1.1**.

This follow #636 and decision at https://github.com/OpenMobileAlliance/lwm2m-registry/pull/639#issuecomment-929375533.

A Leshan PR tries to implement it (but for now Leshan does not support Corelnk data type) : https://github.com/eclipse/leshan/pull/1150

(I don't plan to contribute 3443 for LWM2M v1.2 at short/mid term as Leshan is far to support it, we are still targeting v1.1)

It is strongly advised to first review and merge #647 as this PR uses 3441 object as started point. 

(It should be easier to review commit by commit)