### PR TITLE
Fix RangeEnumeration to specified convention

### DIFF
--- a/10245.xml
+++ b/10245.xml
@@ -47,7 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Mandatory</Mandatory>
                 <Type>Boolean</Type>
-                <RangeEnumeration>AVAILABLE; UNAVAILABLE</RangeEnumeration>
+                <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
                 <Description>This field indicates to the CCC whether or not the eNB of the CrowdBox is available for activation: AVAILABLE = TRUE; UNAVAILABLE = FALSE This is set by the CrowdBox itself using an algorithm specific to the use case and based on parameters known to the CrowdBox which may not necessarily be signalled to the network. In the absence of a more specific algorithm, this parameter should be set to AVAILABLE, unless a fault is detected which would prevent activation of the eNB, in which case it should be set to UNAVAILABLE.</Description>
             </Item>
@@ -57,7 +57,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Mandatory</Mandatory>
                 <Type>Boolean</Type>
-                <RangeEnumeration>UNSYNCHRONISED; SYNCHRONISED</RangeEnumeration>
+                <RangeEnumeration></RangeEnumeration>
                 <Units></Units>
                 <Description>States whether the CrowdBox GPS receiver is synchronised to GPS time or not: UNSYCHRONISED = FALSE; SYNCHRONISED = TRUE If more than one GPS receiver is used by the CrowdBox, then SYNCHRONISED should be reported only if all receivers are synchronised.</Description>
             </Item>
@@ -127,9 +127,9 @@ POSSIBILITY OF SUCH DAMAGE.
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Mandatory</Mandatory>
                 <Type>Integer</Type>
-                <RangeEnumeration>0..2^28-1</RangeEnumeration>
+                <RangeEnumeration>0..268435455</RangeEnumeration>
                 <Units></Units>
-                <Description>A 28 bit E-UTRAN Cell Identifier (ECI)</Description>
+                <Description>A 28 bit E-UTRAN Cell Identifier (ECI) (range 0..2^28-1)</Description>
             </Item>
             <Item ID="9">
                 <Name>eNB Status</Name>

--- a/10246.xml
+++ b/10246.xml
@@ -48,7 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Mandatory</Mandatory>
                 <Type>Integer</Type>
-                <RangeEnumeration>0..2^32-1</RangeEnumeration>
+                <RangeEnumeration>0..4294967295</RangeEnumeration>
                 <Units></Units>
                 <Description>Serving cell ID as specified by the cellIdentity field broadcast in SIB1 of the serving cell (see TS 36.331).</Description>
             </Item>

--- a/10247.xml
+++ b/10247.xml
@@ -58,7 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Optional</Mandatory>
                 <Type>Integer</Type>
-                <RangeEnumeration>0..2^32-1</RangeEnumeration>
+                <RangeEnumeration>0..4294967295</RangeEnumeration>
                 <Units></Units>
                 <Description>Neighbour cell ID as specified by the cellIdentity field broadcast in SIB1 of the neighbour cell (see TS 36.331).</Description>
             </Item>

--- a/10249.xml
+++ b/10249.xml
@@ -58,7 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Mandatory</Mandatory>
                 <Type>Integer</Type>
-                <RangeEnumeration>0..2^32-1</RangeEnumeration>
+                <RangeEnumeration>0..4294967295</RangeEnumeration>
                 <Units></Units>
                 <Description>M-TMSI signalled by the UE to the eNB in the RRCConnectionRequest message (see TS 36.331).</Description>
             </Item>
@@ -108,9 +108,9 @@ POSSIBILITY OF SUCH DAMAGE.
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Mandatory</Mandatory>
                 <Type>Integer</Type>
-                <RangeEnumeration>0..2^32-1</RangeEnumeration>
+                <RangeEnumeration>0..4294967295</RangeEnumeration>
                 <Units>B</Units>
-                <Description>The total number of MAC bytes sent to the connected user over the immediately preceding period specified by the "Cumulative Measurement Window" field.</Description>
+                <Description>The total number of MAC bytes sent to the connected user over the immediately preceding period specified by the "Cumulative Measurement Window" field. A 32 bit value with range 0..2^32-1.</Description>
             </Item>
             <Item ID="7">
                 <Name>Cumulative Uplink Throughput per Connected User</Name>
@@ -118,9 +118,9 @@ POSSIBILITY OF SUCH DAMAGE.
                 <MultipleInstances>Single</MultipleInstances>
                 <Mandatory>Mandatory</Mandatory>
                 <Type>Integer</Type>
-                <RangeEnumeration>0..2^32-1</RangeEnumeration>
+                <RangeEnumeration>0..4294967295</RangeEnumeration>
                 <Units>B</Units>
-                <Description>The total number of MAC bytes received from the connected user over the immediately preceding period specified by the "Cumulative Measurement Window" field.</Description>
+                <Description>The total number of MAC bytes received from the connected user over the immediately preceding period specified by the "Cumulative Measurement Window" field. A 32 bit value with range 0..2^32-1.</Description>
             </Item>
             <Item ID="8">
                 <Name>Neighbour Cell Report</Name>

--- a/10334.xml
+++ b/10334.xml
@@ -109,9 +109,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<MultipleInstances>Single</MultipleInstances>
 			<Mandatory>Mandatory</Mandatory>
 			<Type>Integer</Type>
-			<RangeEnumeration>0..2^63-1</RangeEnumeration>
+			<RangeEnumeration>0..9223372036854775807</RangeEnumeration>
 			<Units></Units>
-			<Description><![CDATA[Sequence No of this alarm, used to detect alarm loss.]]></Description>
+			<Description><![CDATA[Sequence No of this alarm, used to detect alarm loss. A 63 bit value with range 0..2^63-1.]]></Description>
 		</Item>
 		<Item ID="8">
 			<Name>Additional Info</Name>

--- a/10335.xml
+++ b/10335.xml
@@ -77,9 +77,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<MultipleInstances>Single</MultipleInstances>
 			<Mandatory>Mandatory</Mandatory>
 			<Type>Integer</Type>
-			<RangeEnumeration>0..2^63-1</RangeEnumeration>
+			<RangeEnumeration>0..9223372036854775807</RangeEnumeration>
 			<Units></Units>
-			<Description><![CDATA[Sequence No of this event, used to detect event loss.]]></Description>
+			<Description><![CDATA[Sequence No of this event, used to detect event loss. A 63 bit value with range 0..2^63-1.]]></Description>
 		</Item>
 		<Item ID="5">
 			<Name>Additional Info</Name>

--- a/12.xml
+++ b/12.xml
@@ -118,7 +118,7 @@ When disabled radio must also be disabled]]></Description>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Mandatory</Mandatory>
 				<Type>String</Type>
-				<RangeEnumeration>12 bytes </RangeEnumeration>
+				<RangeEnumeration>12</RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[The MAC address of the interface, in hexadecimal form.]]></Description>
 			</Item>
@@ -203,7 +203,7 @@ Including any channels in-use by access point itself.]]></Description>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
 				<Type>String</Type>
-				<RangeEnumeration>3 B</RangeEnumeration>
+				<RangeEnumeration>3</RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[802.11d Regulatory Domain String. 
 First two octets are ISO/IEC 3166-1 two-character country code. 
@@ -254,7 +254,7 @@ The third octet is either " " (all environments), "O" (outside) or "I" (inside).
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
 				<Type>String</Type>
-				<RangeEnumeration>64 B</RangeEnumeration>
+				<RangeEnumeration>64</RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[WPA/WPA2 Key expressed as a hex string. Write - Only.]]></Description>
 			</Item>

--- a/20.xml
+++ b/20.xml
@@ -81,7 +81,7 @@ The Resources of that Object are based on the OMA LwM2M set of reusable Resource
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
 				<Type>Integer</Type>
-				<RangeEnumeration>255</RangeEnumeration>
+				<RangeEnumeration>0..255</RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[ Define the Log Event Class: 0: generic (default)  1: system   2: security  3: event   4: trace   5: panic   6: charging [7-99]: reserved [100-255]: vendor specific ]]></Description>
 			</Item>
@@ -112,7 +112,7 @@ Arguments definitions are described in the table below.]]></Description>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
 				<Type>Integer</Type>
-				<RangeEnumeration>8-Bits</RangeEnumeration>
+				<RangeEnumeration>0..255</RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[Data Collection process status: Each bit of this Resource Instance value defines specific status: 1st LSB 0=running, 1=stopped 2nd LSB 1=LogData contains Valid Data 0=LogData doesn't contain Valid Data 3rd LSB 1=Error occurred during Data Collection 0=No error [4th -7th ] LSB:reserved 8th LSB: vendor specific.]]></Description>
 			</Item>
@@ -130,7 +130,7 @@ Arguments definitions are described in the table below.]]></Description>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
 				<Type>Integer</Type>
-				<RangeEnumeration>255</RangeEnumeration>
+				<RangeEnumeration>0..255</RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[ when set by the Server, this Resource indicates to the Client, what is the Server preferred data format to use when the LogData Resource is returned
 . when retrieved by the Server, this Resource indicates which specific data format is used when the LogData Resource is returned to the Server 

--- a/Common.xml
+++ b/Common.xml
@@ -57,7 +57,7 @@
 
         <Type>Integer</Type>
 
-        <RangeEnumeration>255</RangeEnumeration>
+        <RangeEnumeration>0..255</RangeEnumeration>
         
         <Units></Units>
 
@@ -126,7 +126,7 @@
 
         <Type>Integer</Type>
 
-        <RangeEnumeration>8-Bits</RangeEnumeration>
+        <RangeEnumeration>0..255</RangeEnumeration>
         
         <Units></Units>
 
@@ -172,7 +172,7 @@
 
         <Type>Integer</Type>
 
-        <RangeEnumeration>255</RangeEnumeration>
+        <RangeEnumeration>0..255</RangeEnumeration>
         
         <Units></Units>
         


### PR DESCRIPTION
Two types of changes are included:
- Converted exponent notation to ".." notation
- Split units and range values

Change made in relation to issue: https://github.com/OpenMobileAlliance/LwM2M/issues/764.
Main goal is to make parsing of the RangeEnumeration field easier.

However more issues exist, which will be fixed via a new issue / PR.