### PR TITLE
[ADMIN] remove permanent reference and update copyright

### DIFF
--- a/502.xml
+++ b/502.xml
@@ -2,17 +2,13 @@
 
 <!-- 
 FILE INFORMATION
-OMA Permanent Document
-   File: OMA-SUP-XML_502-V1_0_1-20210119-A
-   Path: https://www.openmobilealliance.org/release/ObjLwM2M_CO_Detector
-   Date: 2021-Jan-19
 Public Reachable Information
    Path: https://github.com/OpenMobileAlliance/lwm2m-registry
    Name: 502.xml
 NORMATIVE INFORMATION
   Send comments to https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues
 LEGAL DISCLAIMER
-Copyright 2021 Open Mobile Alliance. 
+Copyright 2022 Open Mobile Alliance. 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/503.xml
+++ b/503.xml
@@ -2,17 +2,13 @@
 
 <!-- 
 FILE INFORMATION
-OMA Permanent Document
-   File: OMA-SUP-XML_503-V1_0_1-20210119-A
-   Path: https://www.openmobilealliance.org/release/ObjLwM2M_Fire_Alarm
-   Date: 2021-Jan-19
 Public Reachable Information
    Path: https://github.com/OpenMobileAlliance/lwm2m-registry
    Name: 503.xml
 NORMATIVE INFORMATION
   Send comments to https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues
 LEGAL DISCLAIMER
-Copyright 2021 Open Mobile Alliance. 
+Copyright 2022 Open Mobile Alliance. 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/504.xml
+++ b/504.xml
@@ -8,7 +8,7 @@ Public Reachable Information
 NORMATIVE INFORMATION
   Send comments to https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues
 LEGAL DISCLAIMER
-Copyright 2021 Open Mobile Alliance. 
+Copyright 2022 Open Mobile Alliance. 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/505.xml
+++ b/505.xml
@@ -8,7 +8,7 @@ Public Reachable Information
 NORMATIVE INFORMATION
   Send comments to https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues
 LEGAL DISCLAIMER
-Copyright 2021 Open Mobile Alliance. 
+Copyright 2022 Open Mobile Alliance. 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/version_history/502-1_0.xml
+++ b/version_history/502-1_0.xml
@@ -2,17 +2,13 @@
 
 <!-- 
 FILE INFORMATION
-OMA Permanent Document
-   File: OMA-SUP-XML_502-V1_0_1-20210119-A
-   Path: https://www.openmobilealliance.org/release/ObjLwM2M_CO_Detector
-   Date: 2021-Jan-19
 Public Reachable Information
    Path: https://github.com/OpenMobileAlliance/lwm2m-registry
    Name: 502.xml
 NORMATIVE INFORMATION
   Send comments to https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues
 LEGAL DISCLAIMER
-Copyright 2021 Open Mobile Alliance. 
+Copyright 2022 Open Mobile Alliance. 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/version_history/503-1_0.xml
+++ b/version_history/503-1_0.xml
@@ -2,17 +2,13 @@
 
 <!-- 
 FILE INFORMATION
-OMA Permanent Document
-   File: OMA-SUP-XML_503-V1_0_1-20210119-A
-   Path: https://www.openmobilealliance.org/release/ObjLwM2M_Fire_Alarm
-   Date: 2021-Jan-19
 Public Reachable Information
    Path: https://github.com/OpenMobileAlliance/lwm2m-registry
    Name: 503.xml
 NORMATIVE INFORMATION
   Send comments to https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues
 LEGAL DISCLAIMER
-Copyright 2021 Open Mobile Alliance. 
+Copyright 2022 Open Mobile Alliance. 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/version_history/504-1_0.xml
+++ b/version_history/504-1_0.xml
@@ -8,7 +8,7 @@ Public Reachable Information
 NORMATIVE INFORMATION
   Send comments to https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues
 LEGAL DISCLAIMER
-Copyright 2021 Open Mobile Alliance. 
+Copyright 2022 Open Mobile Alliance. 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/version_history/505-1_0.xml
+++ b/version_history/505-1_0.xml
@@ -8,7 +8,7 @@ Public Reachable Information
 NORMATIVE INFORMATION
   Send comments to https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues
 LEGAL DISCLAIMER
-Copyright 2021 Open Mobile Alliance. 
+Copyright 2022 Open Mobile Alliance. 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:


### PR DESCRIPTION
This is an admin PR that removes the reference to the permanent document. This is because IPSO is not using the 3rd digit, and because the publication now is done only in the LwM2M-Registry. Also, the copyright year is updated to reflect the update.
