### PR TITLE
[ADMIN] Set DDFLink to 0 when object file is not available

### DIFF
--- a/DDF.xml
+++ b/DDF.xml
@@ -6200,7 +6200,7 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <Ver>1.0</Ver>
         <DDF></DDF>
         <Vorto></Vorto>
-        <DDFLink>1</DDFLink>
+        <DDFLink>0</DDFLink>
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>
@@ -6214,7 +6214,7 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <Ver>1.0</Ver>
         <DDF></DDF>
         <Vorto></Vorto>
-        <DDFLink>1</DDFLink>
+        <DDFLink>0</DDFLink>
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>
@@ -6228,7 +6228,7 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <Ver>1.0</Ver>
         <DDF></DDF>
         <Vorto></Vorto>
-        <DDFLink>1</DDFLink>
+        <DDFLink>0</DDFLink>
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>
@@ -6242,7 +6242,7 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <Ver>1.0</Ver>
         <DDF></DDF>
         <Vorto></Vorto>
-        <DDFLink>1</DDFLink>
+        <DDFLink>0</DDFLink>
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>
@@ -6256,7 +6256,7 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <Ver>1.0</Ver>
         <DDF></DDF>
         <Vorto></Vorto>
-        <DDFLink>1</DDFLink>
+        <DDFLink>0</DDFLink>
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>
@@ -6270,7 +6270,7 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <Ver>1.0</Ver>
         <DDF></DDF>
         <Vorto></Vorto>
-        <DDFLink>1</DDFLink>
+        <DDFLink>0</DDFLink>
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>
@@ -6284,7 +6284,7 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <Ver>1.0</Ver>
         <DDF></DDF>
         <Vorto></Vorto>
-        <DDFLink>1</DDFLink>
+        <DDFLink>0</DDFLink>
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>


### PR DESCRIPTION
This is a staff PR to resolve an issue in the `prod` DDF.xml. `DDFLink` element must be set to `0` when the Object file is not present in the registry.
