### PR TITLE
update of Object 10481

### DIFF
--- a/10481.xml
+++ b/10481.xml
@@ -32,9 +32,9 @@ POSSIBILITY OF SUCH DAMAGE.
 		<Name>Network Speed Test</Name>
 		<Description1><![CDATA[This Object supports triggering a network speed test and records the results. Furthermore, it allows to configure the server address of the server used for the speed test.]]></Description1>
 		<ObjectID>10481</ObjectID>
-		<ObjectURN>urn:oma:lwm2m:x:10481</ObjectURN>
+		<ObjectURN>urn:oma:lwm2m:x:10481:2.0</ObjectURN>
 		<LWM2MVersion>1.1</LWM2MVersion>
-		<ObjectVersion>1.0</ObjectVersion>
+		<ObjectVersion>2.0</ObjectVersion>
 		<MultipleInstances>Single</MultipleInstances>
 		<Mandatory>Optional</Mandatory>
 		<Resources>
@@ -75,7 +75,7 @@ POSSIBILITY OF SUCH DAMAGE.
 				<Mandatory>Mandatory</Mandatory>
 				<Type>Float</Type>
 				<RangeEnumeration></RangeEnumeration>
-				<Units>MB/s</Units>
+				<Units>Mbit/s</Units>
 				<Description><![CDATA[Download speed]]></Description>
 			</Item>
 			<Item ID="4">
@@ -85,7 +85,7 @@ POSSIBILITY OF SUCH DAMAGE.
 				<Mandatory>Mandatory</Mandatory>
 				<Type>Float</Type>
 				<RangeEnumeration></RangeEnumeration>
-				<Units>MB/s</Units>
+				<Units>Mbit/s</Units>
 				<Description><![CDATA[Upload speed]]></Description>
 			</Item>
 			<Item ID="5">

--- a/DDF.xml
+++ b/DDF.xml
@@ -6331,6 +6331,20 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <TSLink>0</TSLink>
     </Item>
     <Item>
+        <ObjectID>10497</ObjectID>
+        <URN>urn:oma:lwm2m:x:10497</URN>
+        <Name>TBD</Name>
+        <Description>Reservation 10497</Description>
+        <Owner>TBD</Owner>
+        <Source>2</Source>
+        <Ver>1.0</Ver>
+        <DDF></DDF>
+        <Vorto></Vorto>
+        <DDFLink>0</DDFLink>
+        <TS></TS>
+        <TSLink>0</TSLink>
+    </Item>
+    <Item>
         <ObjectID>18830</ObjectID>
         <URN>urn:oma:lwm2m:x:18830</URN>
         <Name>MQTT Broker</Name>

--- a/version_history/10481-2_0.xml
+++ b/version_history/10481-2_0.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?><!--Copyright 2024 Vodafone. 
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/LWM2M-v1_1.xsd">
+	<Object ObjectType="MODefinition">
+		<Name>Network Speed Test</Name>
+		<Description1><![CDATA[This Object supports triggering a network speed test and records the results. Furthermore, it allows to configure the server address of the server used for the speed test.]]></Description1>
+		<ObjectID>10481</ObjectID>
+		<ObjectURN>urn:oma:lwm2m:x:10481:2.0</ObjectURN>
+		<LWM2MVersion>1.1</LWM2MVersion>
+		<ObjectVersion>2.0</ObjectVersion>
+		<MultipleInstances>Single</MultipleInstances>
+		<Mandatory>Optional</Mandatory>
+		<Resources>
+			<Item ID="0">
+				<Name>Perform Speed Test</Name>
+				<Operations>E</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type></Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Start the speed test.]]></Description>
+			</Item>
+			<Item ID="1">
+				<Name>Last updated</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Time</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Timestamp of the last speed test.]]></Description>
+			</Item>
+			<Item ID="2">
+				<Name>Server address</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Server address for the speed test.]]></Description>
+			</Item>
+			<Item ID="3">
+				<Name>Download Speed</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Float</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units>Mbit/s</Units>
+				<Description><![CDATA[Download speed]]></Description>
+			</Item>
+			<Item ID="4">
+				<Name>Upload Speed</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Float</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units>Mbit/s</Units>
+				<Description><![CDATA[Upload speed]]></Description>
+			</Item>
+			<Item ID="5">
+				<Name>Ping Latency</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Float</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units>ms</Units>
+				<Description><![CDATA[Ping latency]]></Description>
+			</Item>
+			
+		</Resources>
+		<Description2 />
+	</Object>
+</LWM2M>


### PR DESCRIPTION
> Note: change from Megabyte per second (MB/s) to Megabit per second (Mbit/s) for uplink and downlink speed.

**In making a submission to the Open Mobile Alliance Registry, you understand and agree that your submission is made under the BSD-3 Clause License as set forth on the Open Mobile Alliance Registry and that additional formats of your submission may be created by the Open Mobile Alliance tools and processes, which may convert the content of your submission, and that the Open Mobile Alliance bears no liability for the additional formats of your submission nor for any conversion of the content of your submission.**
