### PR TITLE
update reusable resource file with missing type values

### DIFF
--- a/reusable_resources_v1_0.xsd
+++ b/reusable_resources_v1_0.xsd
@@ -96,7 +96,7 @@ LEGAL DISCLAIMER
                                 <xs:enumeration value="Time"/>
                                 <xs:enumeration value="Objlnk"/>
                                 <xs:enumeration value="Unsigned Integer"/>
-                                <xs:enumeration value="Corelnk"/>
+                                <xs:enumeration value=/>
                                 <xs:enumeration value=""/>
                               </xs:restriction>
                             </xs:simpleType>

--- a/reusable_resources_v1_0.xsd
+++ b/reusable_resources_v1_0.xsd
@@ -23,10 +23,11 @@ CHANGE HISTORY
 
 20171227 First version
 20180105 Editorial updates
+20250210 Add to Type element missing values: "Unsigned Integer", and "Corelnk". PR #812, https://github.com/OpenMobileAlliance/lwm2m-registry/pull/812 
 
 LEGAL DISCLAIMER
 
-  Copyright 2018 Open Mobile Alliance Ltd.  All rights reserved.
+  Copyright 2018, 2025 Open Mobile Alliance Ltd.  All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -54,7 +55,7 @@ LEGAL DISCLAIMER
   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
-  The above license is used as a license under copyright only.  Please
+  The above license is used as a license under copyright only. Please
   reference the OMA IPR Policy for patent licensing terms:
   http://www.openmobilealliance.org/ipr.html
 
@@ -94,6 +95,8 @@ LEGAL DISCLAIMER
                                 <xs:enumeration value="Opaque"/>
                                 <xs:enumeration value="Time"/>
                                 <xs:enumeration value="Objlnk"/>
+                                <xs:enumeration value="Unsigned Integer"/>
+                                <xs:enumeration value="Corelnk"/>
                                 <xs:enumeration value=""/>
                               </xs:restriction>
                             </xs:simpleType>

--- a/reusable_resources_v1_0.xsd
+++ b/reusable_resources_v1_0.xsd
@@ -96,7 +96,7 @@ LEGAL DISCLAIMER
                                 <xs:enumeration value="Time"/>
                                 <xs:enumeration value="Objlnk"/>
                                 <xs:enumeration value="Unsigned Integer"/>
-                                <xs:enumeration value=/>
+                                <xs:enumeration value="Corelnk"/>
                                 <xs:enumeration value=""/>
                               </xs:restriction>
                             </xs:simpleType>


### PR DESCRIPTION
> Note:

**In making a submission to the Open Mobile Alliance Registry, you understand and agree that your submission is made under the BSD-3 Clause License as set forth on the Open Mobile Alliance Registry and that additional formats of your submission may be created by the Open Mobile Alliance tools and processes, which may convert the content of your submission, and that the Open Mobile Alliance bears no liability for the additional formats of your submission nor for any conversion of the content of your submission.**

This PR adds two values to the element `Type` in alignment with LwM2M v1.1 of the schema.
Type values:
- "Unsigned Integer", and
- "Corelnk"

### Group Agreement
The group agreed to keep the same version (v1.0) on the `reusable_resources_v1_0.xsd` schema rather than update it.

> Note: Currently, the `Common.xml` fetches the  `reusable_resources_v1_0.xsd` schema from the OMA FTP location:  http://www.openmobilealliance.org/tech/profiles/reusable_resources_v1_0.xsd rather than from this repository.

If we want to change the location of the `reusable_resources_v1_0.xsd` schema  to this GitHub repository, we must:
- [ ] Change the url of the `xsi:noNamespaceSchemaLocation` from `xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/reusable_resources_v1_0.xsd`  to xsi:noNamespaceSchemaLocation="/reusable_resources_v1_0.xsd", and
- [ ] set a redirect for `http://www.openmobilealliance.org/tech/profiles/reusable_resources_v1_0.xsd` to `https://raw.githubusercontent.com/OpenMobileAlliance/lwm2m-registry/refs/heads/prod/reusable_resources_v1_0.xsd`