### PR TITLE
[ADMIN] add missing entry for 10539 in the DDF

### DIFF
--- a/DDF.xml
+++ b/DDF.xml
@@ -7313,6 +7313,20 @@ The Object also allows steering the device towards a particular PLMN, or, to a p
         <TS></TS>
         <TSLink>0</TSLink>
     </Item>
+        <Item>
+        <ObjectID>10539</ObjectID>
+        <URN>urn:oma:lwm2m:x:10539</URN>
+        <Name>Modem Firmware Update</Name>
+        <Description>Modem firmware update object.</Description>
+        <Owner>South East Water Corporation</Owner>
+        <Source>2</Source>
+        <Ver>1.0</Ver>
+        <DDF>10539.xml</DDF>
+        <Vorto></Vorto>
+        <DDFLink>1</DDFLink>
+        <TS></TS>
+        <TSLink>0</TSLink>
+    </Item>
     <Item>
         <ObjectID>18830</ObjectID>
         <URN>urn:oma:lwm2m:x:18830</URN>


### PR DESCRIPTION
Object 10539 is already in the `prod` branch, but it is missing the configuration in the DDF.xml.


> Note:

**In making a submission to the Open Mobile Alliance Registry, you understand and agree that your submission is made under the BSD-3 Clause License as set forth on the Open Mobile Alliance Registry and that additional formats of your submission may be created by the Open Mobile Alliance tools and processes, which may convert the content of your submission, and that the Open Mobile Alliance bears no liability for the additional formats of your submission nor for any conversion of the content of your submission.**
