### PR TITLE
[SCWG] Fixed incorrect XML format of object 3457

### DIFF
--- a/3457.xml
+++ b/3457.xml
@@ -242,7 +242,6 @@ Can be eventually adjusted in order to reserve more or less memory]]></Descripti
 				<Units/>
 				<Description><![CDATA[When executed, trigger a complete wipe of schedules already commissioned]]></Description>
 			</Item>
-		</Resources>
 			<Item ID="100">
 				<Name>Transaction start</Name>
 				<Operations>RW</Operations>
@@ -288,6 +287,7 @@ If a timeout happens the device will set an alarm status and may eventually reve
 				<Units/>
 				<Description><![CDATA[This resource is set to true when a transaction is aborted and is automatically cleared when a new transaction is started]]></Description>
 			</Item>
+		</Resources>
 		<Description2/>
 	</Object>
 </LWM2M>

--- a/version_history/3457-1_1.xml
+++ b/version_history/3457-1_1.xml
@@ -242,7 +242,6 @@ Can be eventually adjusted in order to reserve more or less memory]]></Descripti
 				<Units/>
 				<Description><![CDATA[When executed, trigger a complete wipe of schedules already commissioned]]></Description>
 			</Item>
-		</Resources>
 			<Item ID="100">
 				<Name>Transaction start</Name>
 				<Operations>RW</Operations>
@@ -288,6 +287,7 @@ If a timeout happens the device will set an alarm status and may eventually reve
 				<Units/>
 				<Description><![CDATA[This resource is set to true when a transaction is aborted and is automatically cleared when a new transaction is started]]></Description>
 			</Item>
+		</Resources>
 		<Description2/>
 	</Object>
 </LWM2M>


### PR DESCRIPTION
It has been found that XML format for object 3457 in version 1.1 is incorrect due to early closure of Resources tag.
Proposal is to fix and replace existing XML version without incrementing any version, since no semantic change is being indeed introduced.